### PR TITLE
CRAYSAT-1449: Update dependencies

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,12 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [1.5.3] - 2022-06-16
+
+### Changed
+- Updated bugfix versions of dependencies to pull versions from external
+  Artifactory.
+
 ## [1.5.2] - 2022-06-07
 
 ### Changed

--- a/requirements-dev.lock.txt
+++ b/requirements-dev.lock.txt
@@ -2,7 +2,7 @@ attrs==21.4.0
 cachetools==4.2.2
 certifi==2021.5.30
 charset-normalizer==2.0.3
-cfs-config-util==2.0.2
+cfs-config-util==2.0.4
 coverage==5.5
 cray-product-catalog==1.3.2
 google-auth==1.34.0
@@ -21,7 +21,7 @@ PyYAML==5.4.1
 requests==2.26.0
 requests-oauthlib==1.3.0
 rsa==4.7.2
-shasta-install-utility-common==2.3.0
+shasta-install-utility-common==2.3.1
 six==1.16.0
 urllib3==1.26.6
 websocket-client==1.1.0

--- a/requirements.lock.txt
+++ b/requirements.lock.txt
@@ -1,7 +1,7 @@
 attrs==21.4.0
 cachetools==4.2.2
 certifi==2021.5.30
-cfs-config-util==2.0.2
+cfs-config-util==2.0.4
 charset-normalizer==2.0.3
 cray-product-catalog==1.3.2
 google-auth==1.34.0
@@ -18,7 +18,7 @@ PyYAML==5.4.1
 requests==2.26.0
 requests-oauthlib==1.3.0
 rsa==4.7.2
-shasta-install-utility-common==2.3.0
+shasta-install-utility-common==2.3.1
 six==1.16.0
 urllib3==1.26.6
 websocket-client==1.1.0


### PR DESCRIPTION
This commit updates versions of sat-install-utility dependencies,
so that versions built in external Artifactory are pulled.

cfs-config-util: bumped from 2.0.2 to 2.0.4
shasta-install-utility-common: bumped from 2.3.0 to 2.3.1

## Pull Request Checklist

- [X] Version number(s) incremented, if applicable
- [X] Copyrights updated
- [X] License file intact
- [X] Target branch correct
- [X] CHANGELOG.md updated
- [X] Testing is appropriate and complete, if applicable
- [X] [HPC Product Announcement](https://cray.slack.com/archives/C026TVCSXLH) prepared, if applicable

