### PR TITLE
CRAYSAT-1630: Do not activate in the catalog

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -25,6 +25,12 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [1.6.0] - 2023-01-19
+
+### Changed
+- When activating a version, no longer set that version as active in the product
+  catalog.
+
 ## [1.5.6] - 2023-01-13
 
 ### Security

--- a/sat_install_utility/main.py
+++ b/sat_install_utility/main.py
@@ -1,7 +1,7 @@
 #
 # MIT License
 #
-# (C) Copyright 2021-2022 Hewlett Packard Enterprise Development LP
+# (C) Copyright 2021-2023 Hewlett Packard Enterprise Development LP
 #
 # Permission is hereby granted, free of charge, to any person obtaining a
 # copy of this software and associated documentation files (the "Software"),
@@ -126,7 +126,6 @@ def activate(args):
         nexus_credentials_secret_namespace=args.nexus_credentials_secret_namespace
     )
     product_catalog.activate_product_hosted_repos(PRODUCT, args.version)
-    product_catalog.activate_product_entry(PRODUCT, args.version)
 
     # TODO (CRAYSAT-1262): Abstract this into shasta-install-utility-common
     product_version = product_catalog.get_product(PRODUCT, args.version)

--- a/tests/test_main.py
+++ b/tests/test_main.py
@@ -1,7 +1,7 @@
 #
 # MIT License
 #
-# (C) Copyright 2021-2022 Hewlett Packard Enterprise Development LP
+# (C) Copyright 2021-2023 Hewlett Packard Enterprise Development LP
 #
 # Permission is hereby granted, free of charge, to any person obtaining a
 # copy of this software and associated documentation files (the "Software"),
@@ -80,6 +80,7 @@ class TestActivateUninstall(unittest.TestCase):
             nexus_credentials_secret_namespace='mock_nexus_secret_namespace'
         )
         self.mock_product_catalog.activate_product_hosted_repos.assert_called_once_with(PRODUCT, 'mock_version')
+        self.mock_product_catalog.activate_product_entry.assert_not_called()
 
         self.mock_cfs_activate.assert_called_once_with(
             'sat',


### PR DESCRIPTION
This commit changes the activate() function so that activating a version of SAT no longer updates the 'active' field in the product catalog.

Test Description:
* On an internal system, I temporarily set a version of "sat" as inactive, then ran `prodmgr activate` on it using this version of sat-install-utility, and verified that the version was not set as "active".
* Added a unit test which failed without the change to main.py.

## Summary and Scope

See commit message

## Issues and Related PRs

_List and characterize relationship to Jira/Github issues and other pull requests. Be sure to list dependencies._

* Resolves CRAYSAT-1630

## Testing

See commit message

## Risks and Mitigations

This is a low-risk change because it has been thoroughly tested, and `sat-install-utility` is in the process of being replaced.

## Pull Request Checklist

- [X] Version number(s) incremented, if applicable
- [X] Copyrights updated
- [X] License file intact
- [X] Target branch correct
- [X] CHANGELOG.md updated
- [X] Testing is appropriate and complete, if applicable
- [X] [HPC Product Announcement](https://cray.slack.com/archives/C026TVCSXLH) prepared, if applicable