### PR TITLE
CASMCMS-8713: Bump PyYAML from 5.4.1 to 6.0.1 to prevent build issue

### DIFF
--- a/requirements-dev.lock.txt
+++ b/requirements-dev.lock.txt
@@ -17,7 +17,7 @@ pyasn1-modules==0.2.8
 pycodestyle==2.7.0
 pyrsistent==0.18.0
 python-dateutil==2.8.2
-PyYAML==5.4.1
+PyYAML==6.0.1
 requests==2.31.0
 requests-oauthlib==1.3.0
 rsa==4.7.2

--- a/requirements.lock.txt
+++ b/requirements.lock.txt
@@ -14,7 +14,7 @@ pyasn1==0.4.8
 pyasn1-modules==0.2.8
 pyrsistent==0.18.0
 python-dateutil==2.8.2
-PyYAML==5.4.1
+PyYAML==6.0.1
 requests==2.31.0
 requests-oauthlib==1.3.0
 rsa==4.7.2

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,5 +1,5 @@
 # Top-level requirements for sat-install-utility
-# (C) Copyright 2021 Hewlett Packard Enterprise Development LP.
+# (C) Copyright 2021, 2023 Hewlett Packard Enterprise Development LP.
 shasta-install-utility-common >= 2.3.0, < 3.0
 cfs-config-util >= 2.0.2, < 3.0
-PyYAML < 6.0.0
+PyYAML == 6.0.1


### PR DESCRIPTION
## Summary and Scope

With the release of Cython 3, any Alpine images trying to install PyYAML hit failures due to [this upstream issue](https://github.com/yaml/pyyaml/issues/601). See [CASMCMS-8713](https://jira-pro.it.hpe.com:8443/browse/CASMCMS-8713) for full details. The TL;DR summary is that moving to PyYAML 6.0.1 resolves the problem. 

There is no functional difference between PyYAML 6.0 and 6.0.1. The only difference is that 6.0.1 imposes a restriction on the Cython version used to build the module during installs. Specifically, it requires Cython < 3, which is the same behavior as PyYAML 6.0 had up until Cython 3 was released.

However, this repo is currently using PyYAML 5.4.1. Unfortunately, there is no PyYAML fix for that version. The maintainers have said that they will consider backporting a fix, but are not willing to commit to it. This leaves affected users of 5.4.1 two options -- move to 6.0.1 or work around the problem. You can see my ticket above for details on how to work around it, if desired. However, I think for this repository, moving to 6.0.1 is the better solution. I have reviewed the breaking changes between 5.4 and 6.0, and they are:
- Dropped support for Python 2.7 and 3.5
- The `load()` and `load_all()` functions now require the Loader argument (previously it was optional).
- Removed `YAMLLoadWarning` definition (since it was warning about the absence of the previous argument)

This repo is using Alpine 3.15, which is using a Python version > 3.5, so the dropped support doesn't matter. And I searched the Python code in the repo, and it does not call either of the functions with the newly required argument. It also does not use the removed `YAMLLoadWarning`. So the move to 6.0.1 should cause no problems.

This PR allows builds in this repo to once again work, while making no functional changes to the things being built.

## Issues and Related PRs

* [PyYAML upstream issue](https://github.com/yaml/pyyaml/issues/601)
* [PR that created PyYAML 6.0.1 to fix the problem](https://github.com/yaml/pyyaml/pull/702)
* [CASMCMS-8713](https://jira-pro.it.hpe.com:8443/browse/CASMCMS-8713) - The Jira ticket I'm using to fix the affected CSM repos

## Risks and Mitigations

Very low risk. And without this, the repo builds will fail.

## Pull Request Checklist

- [X] License file intact
- [X] Target branch correct
